### PR TITLE
Error handling incorrect restaurant lookup; addressing minor comments from previous PR

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import { Provider } from "react-redux";
 import store from "./redux/store";
-import { Breadcrumb, Header } from './components/Common';
+import { Header } from './components/Common';
 import { routes } from "./routes"
 
 function App() {

--- a/frontend/src/components/Reviews/index.jsx
+++ b/frontend/src/components/Reviews/index.jsx
@@ -5,11 +5,13 @@ import { Breadcrumb, ErrorBanner, FrySpinner, LinkButton, RestaurantHeader } fro
 
 const propTypes = {
     reviews: PropTypes.array.isRequired,
-    error: PropTypes.string.isRequired,
-    currentRestaurant: PropTypes.string.isRequired
+    reviewsError: PropTypes.string.isRequired,
+    restaurantsError: PropTypes.string.isRequired,
+    currentRestaurant: PropTypes.string.isRequired,
+    requestingRestaurantDetails: PropTypes.bool.isRequired
 };
 
-const Reviews = ({ reviews, error, currentRestaurant }) => {
+const Reviews = ({ reviews, reviewsError, restaurantsError, currentRestaurant, requestingRestaurantDetails }) => {
 
     const reviewsBody = () => {
         if (reviews.length == 0) {
@@ -21,26 +23,27 @@ const Reviews = ({ reviews, error, currentRestaurant }) => {
         }
     }
 
-    if (!currentRestaurant) {
-        return <FrySpinner />;
-    }
-
     return (
         <div>
-            <ErrorBanner error = {error} />
+            <ErrorBanner error = {reviewsError} />
+            <ErrorBanner error = {restaurantsError} />
             <Breadcrumb />
-            <RestaurantHeader currentRestaurant = {currentRestaurant} />
-            {reviews && reviewsBody()}
-            <LinkButton
-                link={'/restaurants/' + currentRestaurant.id + '/create'}
-                children='Write a review'
-                color='danger'
-            />
-            <LinkButton
-                link='/restaurants/'
-                children='Back to all restaurants'
-                color='secondary'
-            />
+            { requestingRestaurantDetails && <FrySpinner /> }
+            { currentRestaurant &&
+                <div>
+                   <RestaurantHeader currentRestaurant = {currentRestaurant} />
+                   {reviews && reviewsBody()}
+                   <LinkButton
+                       link={'/restaurants/' + currentRestaurant.id + '/create'}
+                       children='Write a review'
+                       color='danger'
+                   />
+                   <LinkButton
+                       link='/restaurants/'
+                       children='Back to all restaurants'
+                       color='secondary'
+                   />
+                </div> }
         </div>
     )
 }

--- a/frontend/src/containers/CreateReview/index.jsx
+++ b/frontend/src/containers/CreateReview/index.jsx
@@ -32,10 +32,7 @@ export default compose(
         componentDidUpdate() {
             const { match: { params: { restaurantId } }, successfulCreate, history } = this.props;
             if (successfulCreate) {
-                setTimeout(
-                    () => history.push(`/restaurants/${restaurantId}`),
-                    5000, // Wait for 5s
-                );
+                history.push(`/restaurants/${restaurantId}`);
             }
         },
     }),

--- a/frontend/src/containers/Reviews/index.jsx
+++ b/frontend/src/containers/Reviews/index.jsx
@@ -8,7 +8,9 @@ const mapStateToProps = (state) => {
     return {
         reviews: state.reviewsReducer.reviews,
         currentRestaurant: state.restaurantsReducer.currentRestaurant,
-        error: state.reviewsReducer.error
+        reviewsError: state.reviewsReducer.error,
+        restaurantsError: state.restaurantsReducer.error,
+        requestingRestaurantDetails: state.restaurantsReducer.requestingRestaurantDetails
     }
 }
 

--- a/frontend/src/redux/reducers/restaurants/index.js
+++ b/frontend/src/redux/reducers/restaurants/index.js
@@ -10,7 +10,8 @@ export const types = {
 export const initialState = {
   restaurants: [],
   currentRestaurant: null,
-  error: ''
+  error: '',
+  requestingRestaurantDetails: false,
 };
 
 export default (state = initialState, action) => {
@@ -38,7 +39,8 @@ export default (state = initialState, action) => {
 
         case types.GET_RESTAURANT_BY_ID_REQUEST: {
             return {
-                ...state
+                ...state,
+                requestingRestaurantDetails: true,
             };
         }
 
@@ -46,7 +48,8 @@ export default (state = initialState, action) => {
             return {
                 ...state,
                currentRestaurant: action.data,
-               error: ''
+               error: '',
+               requestingRestaurantDetails: false,
             }
         }
 
@@ -54,6 +57,7 @@ export default (state = initialState, action) => {
             return {
                 ...state,
                 error: action.error,
+                requestingRestaurantDetails: false,
             }
         }
 

--- a/frontend/src/redux/sagas/restaurants/index.js
+++ b/frontend/src/redux/sagas/restaurants/index.js
@@ -20,7 +20,7 @@ export function* callGetRestaurantById({ restaurantId }) {
         const { data } = yield axios.get(API_PATH, { params: { restaurantId } });
         yield put(restaurantsActions.successfulGetRestaurantByIdRequest(data));
     } catch (err) {
-        yield put(restaurantsActions.failedGetRestaurantByIdRequest('Failed getting a restaurant for the requested ID'));
+        yield put(restaurantsActions.failedGetRestaurantByIdRequest(err.response.data.message));
     }
 }
 

--- a/src/main/java/com/fryrank/dal/RestaurantDALImpl.java
+++ b/src/main/java/com/fryrank/dal/RestaurantDALImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class RestaurantDALImpl implements RestaurantDAL {
@@ -20,7 +21,8 @@ public class RestaurantDALImpl implements RestaurantDAL {
 
     @Override
     public Restaurant getRestaurantById(@NonNull final String restaurantId) {
-        return mongoTemplate.findById(restaurantId, Restaurant.class);
+        final Optional<Restaurant> restaurant = Optional.ofNullable(mongoTemplate.findById(restaurantId, Restaurant.class));
+        return restaurant.orElseThrow(() -> new NullPointerException(String.format("A restaurant does not exist for the requested ID %s.", restaurantId)));
     }
 
     @Override


### PR DESCRIPTION
- When navigating to a page for an invalid restaurant ID, it displays an error message, rather than forever showing the loading spinner
- On the backend, throw an exception when no restaurant is found in the DB for the given ID
- Modify the reducer to keep track of the request to get the restaurant details, so the page knows whether to show the loader or not