### PR TITLE
Add heroku-postbuild step to package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "heroku-postbuild": "react-scripts build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This will configure heroku to build npm properly on the same dyno the backend is currently deployed on.