### PR TITLE
Enhanced error handling on UI: Display Google error message and handle searches that provide no results

### DIFF
--- a/frontend/src/components/Common/ErrorBanner/index.jsx
+++ b/frontend/src/components/Common/ErrorBanner/index.jsx
@@ -7,7 +7,7 @@ const propTypes = {
 
 const ErrorBanner = ({ error }) => {
     return error
-        ? <Alert color="danger">{error}</Alert>
+        ? <Alert color="danger">Error: {error}</Alert>
         : null;
 }
 

--- a/frontend/src/components/Restaurants/index.jsx
+++ b/frontend/src/components/Restaurants/index.jsx
@@ -1,6 +1,6 @@
 import { PropTypes } from 'prop-types';
 import { Fragment } from 'react';
-import { AddressDisplay, Breadcrumb, FrySpinner } from '../Common';
+import { AddressDisplay, Breadcrumb, ErrorBanner, FrySpinner } from '../Common';
 import SearchInput from './SearchInput';
 import { BASE_URL, PATH_REVIEWS, PATH_VARIABLE_RESTAURANT_ID } from '../../constants.js'
 
@@ -15,19 +15,21 @@ const propTypes = {
 const Restaurants = ({ restaurants, error, getRestaurants, currentSearchQuery, updateSearchQuery }) => {
 
     const restaurantsDisplay = (restaurants) => {
-        return restaurants.map((restaurant, i) => {
-            let restaurantLink = `${BASE_URL}${PATH_REVIEWS}`.replace(PATH_VARIABLE_RESTAURANT_ID, restaurant.id)
-            return (
-                <Fragment key = {i}>
-                    <p><b><a href={restaurantLink}>{restaurant.displayName.text}</a></b></p>
-                    <p>{restaurant.formattedAddress}</p>
-                </Fragment>
-            )
-        });
+        return restaurants
+            ? restaurants.map((restaurant, i) => {
+                let restaurantLink = `${BASE_URL}${PATH_REVIEWS}`.replace(PATH_VARIABLE_RESTAURANT_ID, restaurant.id)
+                return (
+                    <Fragment key = {i}>
+                        <p><b><a href={restaurantLink}>{restaurant.displayName.text}</a></b></p>
+                        <p>{restaurant.formattedAddress}</p>
+                    </Fragment>
+                )})
+            : 'No restaurants found for this search.';
     }
 
     return (
         <div>
+            <ErrorBanner error = {error} />
             <Breadcrumb />
             <SearchInput
                 getRestaurants = {getRestaurants}

--- a/frontend/src/redux/sagas/restaurants/index.js
+++ b/frontend/src/redux/sagas/restaurants/index.js
@@ -21,7 +21,7 @@ export function* callGetRestaurants({ textQuery }) {
         );
         yield put(restaurantsActions.successfulGetRestaurantsRequest(data));
     } catch (err) {
-        yield put(restaurantsActions.failedGetRestaurantsRequest('Failed getting restaurants from Google'));
+        yield put(restaurantsActions.failedGetRestaurantsRequest(err.response.data.error.message));
     }
 }
 
@@ -36,7 +36,7 @@ export function* callGetRestaurantById({ restaurantId }) {
         );
         yield put(restaurantsActions.successfulGetRestaurantByIdRequest(data));
     } catch (err) {
-        yield put(restaurantsActions.failedGetRestaurantByIdRequest('Failed getting restaurant details from Google'));
+        yield put(restaurantsActions.failedGetRestaurantByIdRequest(err.response.data.error.message));
     }
 
 }


### PR DESCRIPTION
- Error messages now show as "Error: [error message]" so that it is more clear to the user
- Handle a null restaurants list being returned by Google (this is what happens when a result returns zero results from Google) by showing a message indicating no restaurants were found.
- Pass through the exact Google error message so that it is clearer to the user what the underlying cause might be (ideally, we provide our own messages to the user based on the error type returned by Google, but displaying the Google error message is better than providing a generic message)